### PR TITLE
Add periodic Strava sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,4 +31,6 @@ raw_files = requests.get(f"{base}/raw").json()
 print(activities, raw_files)
 ```
 
+The service automatically downloads the last ten Strava activities on startup and checks for new ones every five minutes.
+
 The included `abcy-data.postman_collection.json` can be imported into Postman for manual exploration of the API.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "anyhow",
+ "async-trait",
  "dotenvy",
  "fitparser",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 dotenvy = "0.15"
 anyhow = "1.0"
+async-trait = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "time"] }

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ cargo run
 
 On startup the app will:
 
-1. Query your Strava activities and download the latest one as a `.fit` file.
-2. Parse the file and write a `<activity_id>.parquet` file to `DATA_DIR`.
-3. Start an HTTP server on `localhost:8080`.
+1. Query your last ten Strava activities and download any that do not already have a corresponding Parquet file.
+2. Parse each new file and write a `<activity_id>.parquet` file to `DATA_DIR`.
+3. Begin checking for new activities every five minutes in the background.
+4. Start an HTTP server on `localhost:8080`.
 
 ### API Endpoints
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod strava;
 pub mod fit_parser;
 pub mod storage;
 pub mod api;
+pub mod sync;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use abcy_data::{config::Config, strava::StravaClient, fit_parser::parse_fit_file, storage::Storage, api};
+use abcy_data::{config::Config, strava::StravaClient, storage::Storage, api, sync};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -7,16 +7,8 @@ async fn main() -> anyhow::Result<()> {
     let client = StravaClient::new(config.clone());
     let storage = Storage::new(&config.data_dir);
 
-    // Example workflow: list activities and download first one
-    let activities = client.get_latest_activities().await?;
-    if let Some(act) = activities.first() {
-        let fit_path = format!("{}/{}.fit", config.data_dir, act.id);
-        if client.download_fit(act.id, std::path::Path::new(&fit_path)).await.is_ok() {
-            if let Ok(points) = parse_fit_file(std::path::Path::new(&fit_path)) {
-                storage.save_activity(act.id, &points)?;
-            }
-        }
-    }
+    // spawn background sync
+    tokio::spawn(sync::run_periodic_sync(client.clone(), storage.clone()));
 
     // start API
     api::run_server(storage).await?;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,6 +13,10 @@ impl Storage {
         Self { data_dir: dir.into() }
     }
 
+    pub fn has_activity(&self, activity_id: u64) -> bool {
+        self.data_dir.join(format!("{}.parquet", activity_id)).exists()
+    }
+
     pub fn save_activity(&self, activity_id: u64, points: &[DataPoint]) -> PolarsResult<()> {
         let timestamp: Vec<Option<i64>> = points.iter().map(|p| p.timestamp).collect();
         let power: Vec<Option<i64>> = points.iter().map(|p| p.power).collect();

--- a/src/strava.rs
+++ b/src/strava.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use std::path::Path;
 use tokio::fs;
 use crate::config::Config;
+use async_trait::async_trait;
 
 #[derive(Debug, Deserialize)]
 pub struct ActivitySummary {
@@ -12,6 +13,7 @@ pub struct ActivitySummary {
     pub distance: f64,
 }
 
+#[derive(Clone)]
 pub struct StravaClient {
     http: Client,
     config: Config,
@@ -21,18 +23,35 @@ impl StravaClient {
     pub fn new(config: Config) -> Self {
         Self { http: Client::new(), config }
     }
+}
 
-    pub async fn get_latest_activities(&self) -> anyhow::Result<Vec<ActivitySummary>> {
-        let url = format!("https://www.strava.com/api/v3/athlete/activities?access_token={}", self.config.strava_refresh_token);
+#[async_trait]
+pub trait StravaApi {
+    async fn get_latest_activities(&self, per_page: usize) -> anyhow::Result<Vec<ActivitySummary>>;
+    async fn download_fit(&self, activity_id: u64, out_path: &Path) -> anyhow::Result<()>;
+}
+
+#[async_trait]
+impl StravaApi for StravaClient {
+    async fn get_latest_activities(&self, per_page: usize) -> anyhow::Result<Vec<ActivitySummary>> {
+        let url = format!(
+            "https://www.strava.com/api/v3/athlete/activities?per_page={}&access_token={}",
+            per_page, self.config.strava_refresh_token
+        );
         let resp = self.http.get(url).send().await?;
         let activities = resp.json::<Vec<ActivitySummary>>().await?;
         Ok(activities)
     }
 
-    pub async fn download_fit(&self, activity_id: u64, out_path: &Path) -> anyhow::Result<()> {
-        let url = format!("https://www.strava.com/api/v3/activities/{}/export_original?access_token={}", activity_id, self.config.strava_refresh_token);
+    async fn download_fit(&self, activity_id: u64, out_path: &Path) -> anyhow::Result<()> {
+        let url = format!(
+            "https://www.strava.com/api/v3/activities/{}/export_original?access_token={}",
+            activity_id, self.config.strava_refresh_token
+        );
         let bytes = self.http.get(url).send().await?.bytes().await?;
-        if let Some(dir) = out_path.parent() { fs::create_dir_all(dir).await?; }
+        if let Some(dir) = out_path.parent() {
+            fs::create_dir_all(dir).await?;
+        }
         fs::write(out_path, &bytes).await?;
         Ok(())
     }

--- a/tests/storage_tests.rs
+++ b/tests/storage_tests.rs
@@ -11,4 +11,5 @@ fn save_activity_creates_parquet() {
     storage.save_activity(42, &points).unwrap();
     let file = dir.path().join("42.parquet");
     assert!(file.exists());
+    assert!(storage.has_activity(42));
 }

--- a/tests/sync_tests.rs
+++ b/tests/sync_tests.rs
@@ -1,0 +1,48 @@
+use abcy_data::{storage::Storage, strava::{ActivitySummary, StravaApi}, sync};
+use tempfile::tempdir;
+use async_trait::async_trait;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+struct DummyClient {
+    downloads: Arc<Mutex<usize>>,
+}
+
+impl DummyClient {
+    fn new() -> Self {
+        Self { downloads: Arc::new(Mutex::new(0)) }
+    }
+}
+
+#[async_trait]
+impl StravaApi for DummyClient {
+    async fn get_latest_activities(&self, _per_page: usize) -> anyhow::Result<Vec<ActivitySummary>> {
+        Ok(vec![ActivitySummary { id: 99, name: "x".into(), start_date: "".into(), distance: 0.0 }])
+    }
+
+    async fn download_fit(&self, _activity_id: u64, out_path: &Path) -> anyhow::Result<()> {
+        *self.downloads.lock().unwrap() += 1;
+        tokio::fs::write(out_path, b"dummy").await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn sync_downloads_missing_activity() {
+    let dir = tempdir().unwrap();
+    let storage = Storage::new(dir.path());
+    let client = DummyClient::new();
+    sync::sync_latest(&client, &storage, 10).await.unwrap();
+    assert!(dir.path().join("99.fit").exists());
+    assert_eq!(*client.downloads.lock().unwrap(), 1);
+}
+
+#[tokio::test]
+async fn sync_skips_existing_activity() {
+    let dir = tempdir().unwrap();
+    let storage = Storage::new(dir.path());
+    std::fs::write(dir.path().join("99.parquet"), b"x").unwrap();
+    let client = DummyClient::new();
+    sync::sync_latest(&client, &storage, 10).await.unwrap();
+    assert_eq!(*client.downloads.lock().unwrap(), 0);
+}


### PR DESCRIPTION
## Summary
- sync last ten activities on startup
- poll Strava every five minutes for new activities
- expose sync module and tests
- document automatic syncing in README and AGENTS

## Testing
- `cargo check`
- `RUSTFLAGS="-C link-arg=-Wl,--no-keep-memory" cargo test -- --test-threads=1` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_685aa9305ecc8320b9511244f2a1f21d