### PR TITLE
Improve sync logging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use abcy_data::{config::Config, strava::StravaClient, storage::Storage, api, sync};
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -8,9 +9,11 @@ async fn main() -> anyhow::Result<()> {
     let storage = Storage::new(&config.data_dir);
 
     // spawn background sync
+    info!("spawning background sync task");
     tokio::spawn(sync::run_periodic_sync(client.clone(), storage.clone()));
 
     // start API
+    info!("starting HTTP server");
     api::run_server(storage).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- log when background sync is spawned and the HTTP server starts
- add logs for Strava requests and saved files
- detail when periodic sync runs and activities are skipped

## Testing
- `RUSTFLAGS="-C link-arg=-Wl,--no-keep-memory" cargo test -- --test-threads=1` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ac1a0ca4c832089bc65e37b51497a