### PR TITLE
Improve Strava logging for debugging

### DIFF
--- a/abcy-data.postman_collection.json
+++ b/abcy-data.postman_collection.json
@@ -18,6 +18,13 @@
         "method": "GET",
         "url": "{{base_url}}/raw"
       }
+    },
+    {
+      "name": "Check Strava API",
+      "request": {
+        "method": "GET",
+        "url": "{{strava_base}}/api/v3/athlete/activities?per_page=1&access_token={{access_token}}"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- log Strava request URLs and response statuses
- log failures when Strava responds with errors
- show request details when downloading FIT files
- extend Postman collection with a request that calls Strava directly

## Testing
- `cargo test` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ac9736efc8320b89879c7fffc2a50