### PR TITLE
Fix Strava authentication usage

### DIFF
--- a/abcy-data.postman_collection.json
+++ b/abcy-data.postman_collection.json
@@ -20,10 +20,32 @@
       }
     },
     {
+      "name": "Refresh Access Token",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+        ],
+        "body": {
+          "mode": "urlencoded",
+          "urlencoded": [
+            { "key": "client_id", "value": "{{client_id}}", "type": "text" },
+            { "key": "client_secret", "value": "{{client_secret}}", "type": "text" },
+            { "key": "refresh_token", "value": "{{refresh_token}}", "type": "text" },
+            { "key": "grant_type", "value": "refresh_token", "type": "text" }
+          ]
+        },
+        "url": "{{strava_base}}/oauth/token"
+      }
+    },
+    {
       "name": "Check Strava API",
       "request": {
         "method": "GET",
-        "url": "{{strava_base}}/api/v3/athlete/activities?per_page=1&access_token={{access_token}}"
+        "header": [
+          { "key": "Authorization", "value": "Bearer {{access_token}}", "type": "text" }
+        ],
+        "url": "{{strava_base}}/api/v3/athlete/activities?per_page=1"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- refresh Strava access token before requests
- send access token via `Authorization` header
- update Postman collection to include token refresh request

## Testing
- `cargo check`
- `RUSTFLAGS="-C link-arg=-Wl,--no-keep-memory" cargo test -- --test-threads=1` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ae2e3c09c83208a0ac6fd39c20b36