### PR TITLE
Add Strava webhook support

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,10 @@
-use actix_web::{get, web, App, HttpServer, Responder};
-use serde::Serialize;
+use actix_web::{get, post, web, App, HttpServer, Responder, HttpResponse};
+use serde::{Serialize, Deserialize};
 use crate::storage::Storage;
+use crate::{strava::StravaClient, sync};
 use std::fs;
 use std::ffi::OsStr;
+use std::collections::HashMap;
 
 #[derive(Serialize)]
 struct ApiActivity {
@@ -44,12 +46,48 @@ async fn list_raw_files(storage: web::Data<Storage>) -> impl Responder {
     web::Json(files)
 }
 
-pub async fn run_server(storage: Storage) -> std::io::Result<()> {
+#[get("/webhook")]
+async fn webhook_verify(query: web::Query<HashMap<String, String>>) -> impl Responder {
+    if let Some(ch) = query.get("hub.challenge") {
+        HttpResponse::Ok().json(serde_json::json!({"hub.challenge": ch}))
+    } else {
+        HttpResponse::BadRequest().finish()
+    }
+}
+
+#[derive(Deserialize)]
+struct WebhookEvent {
+    #[allow(dead_code)]
+    object_type: String,
+    #[allow(dead_code)]
+    aspect_type: String,
+}
+
+#[post("/webhook")]
+async fn webhook_event(
+    client: web::Data<StravaClient>,
+    storage: web::Data<Storage>,
+    event: web::Json<WebhookEvent>,
+) -> impl Responder {
+    if event.object_type == "activity" && event.aspect_type == "create" {
+        let client = client.clone();
+        let storage = storage.clone();
+        tokio::spawn(async move {
+            let _ = sync::sync_latest::<StravaClient>(&*client, &storage, 1).await;
+        });
+    }
+    HttpResponse::Ok()
+}
+
+pub async fn run_server(storage: Storage, client: StravaClient) -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .app_data(web::Data::new(storage.clone()))
+            .app_data(web::Data::new(client.clone()))
             .service(list_activities)
             .service(list_raw_files)
+            .service(webhook_verify)
+            .service(webhook_event)
     })
     .bind(("0.0.0.0", 8080))?
     .run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,6 @@ async fn main() -> anyhow::Result<()> {
 
     // start API
     info!("starting HTTP server");
-    api::run_server(storage).await?;
+    api::run_server(storage, client).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- expose webhook GET/POST endpoints so Strava can notify on new activities
- include StravaClient in HTTP server startup

## Testing
- `cargo check`
- `cargo test` *(fails: linking step exceeded available memory)*

------
https://chatgpt.com/codex/tasks/task_e_685aed044b608320bc7010f5f5fc7b9c