### PR TITLE
Add fit file endpoints and metadata storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,9 @@ The server listens on `localhost:8080` by default.
 ## HTTP endpoints
 
 - `GET /activities` – returns a JSON array of activity IDs that have been processed.
-- `GET /raw` – returns a JSON array of `.fit` file names in `DATA_DIR`.
+- `GET /raw` – returns a JSON array of `.fit` file names in `DATA_DIR/raw`.
+- `GET /fit/{id}` – download the raw `.fit` file for an activity.
+- `GET /fit/{id}/details` – JSON data parsed from the `.fit` file.
 
 ## Python usage
 
@@ -28,7 +30,8 @@ base = "http://localhost:8080"
 
 activities = requests.get(f"{base}/activities").json()
 raw_files = requests.get(f"{base}/raw").json()
-print(activities, raw_files)
+first = requests.get(f"{base}/fit/{activities[0]['id']}") if activities else None
+print(activities, raw_files, first is not None)
 ```
 
 The service automatically downloads the last ten Strava activities on startup and checks for new ones every five minutes.

--- a/README.md
+++ b/README.md
@@ -66,21 +66,26 @@ cargo run
 
 On startup the app will:
 
-1. Query your last ten Strava activities and download any that do not already have a corresponding Parquet file.
-2. Parse each new file and write a `<activity_id>.parquet` file to `DATA_DIR`.
-3. Begin checking for new activities every five minutes in the background.
-4. Start an HTTP server on `localhost:8080`.
+1. Query your last ten Strava activities and store their metadata in `metadata.parquet`.
+2. Download each activity's original `.fit` file to `DATA_DIR/raw/` if it is not already present.
+3. Parse each new file and write a `<activity_id>.parquet` file to `DATA_DIR`.
+4. Begin checking for new activities every five minutes in the background.
+5. Start an HTTP server on `localhost:8080`.
 
 ### API Endpoints
 
 - `GET /activities` – list the IDs of stored activities.
-- `GET /raw` – list the `.fit` files in `DATA_DIR`.
+- `GET /raw` – list the `.fit` files in `DATA_DIR/raw`.
+- `GET /fit/{id}` – download the raw `.fit` file for an activity.
+- `GET /fit/{id}/details` – return parsed records from the `.fit` file.
 
 A Postman collection `abcy-data.postman_collection.json` is included to help
 test the endpoints. Set the `base_url` variable to your server's address.
 Automated tools can refer to `AGENTS.md` for a short Python example.
 
-Each activity is stored as a Parquet file inside `DATA_DIR` and can be processed further using your preferred tools.
+Each activity's time series data is stored as `<id>.parquet` inside `DATA_DIR`.
+Metadata for all rides lives in `DATA_DIR/metadata.parquet` and references the
+corresponding raw `.fit` files stored under `DATA_DIR/raw/`.
 
 ## Adding Another User
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,5 @@
 use polars::prelude::*;
+use crate::strava::ActivitySummary;
 use std::fs::File;
 use std::path::PathBuf;
 use crate::fit_parser::DataPoint;
@@ -11,6 +12,33 @@ pub struct Storage {
 impl Storage {
     pub fn new<P: Into<PathBuf>>(dir: P) -> Self {
         Self { data_dir: dir.into() }
+    }
+
+    pub fn fit_file_path(&self, activity_id: u64) -> PathBuf {
+        self.data_dir.join("raw").join(format!("{}.fit", activity_id))
+    }
+
+    pub fn metadata_path(&self) -> PathBuf {
+        self.data_dir.join("metadata.parquet")
+    }
+
+    pub fn has_fit_file(&self, activity_id: u64) -> bool {
+        self.fit_file_path(activity_id).exists()
+    }
+
+    pub fn has_metadata(&self, activity_id: u64) -> bool {
+        let path = self.metadata_path();
+        if !path.exists() {
+            return false;
+        }
+        if let Ok(df) = ParquetReader::new(File::open(path).unwrap()).finish() {
+            if let Ok(series) = df.column("id") {
+                if let Ok(ca) = series.u64() {
+                    return ca.into_no_null_iter().any(|v| v == activity_id);
+                }
+            }
+        }
+        false
     }
 
     pub fn has_activity(&self, activity_id: u64) -> bool {
@@ -35,6 +63,36 @@ impl Storage {
         std::fs::create_dir_all(&self.data_dir)?;
         let file = File::create(path)?;
         ParquetWriter::new(file).finish(&mut df)?;
+        Ok(())
+    }
+
+    pub fn save_metadata(&self, act: &ActivitySummary) -> PolarsResult<()> {
+        let path = self.metadata_path();
+        std::fs::create_dir_all(self.data_dir.join("raw"))?;
+        let fit_file = self.fit_file_path(act.id).display().to_string();
+        let mut new_df = df![
+            "id" => [act.id],
+            "name" => [act.name.as_str()],
+            "start_date" => [act.start_date.as_str()],
+            "distance" => [act.distance],
+            "fit_file" => [fit_file.as_str()],
+        ]?;
+        if path.exists() {
+            let mut df = ParquetReader::new(File::open(&path)?).finish()?;
+            if let Ok(series) = df.column("id") {
+                if let Ok(ca) = series.u64() {
+                    if ca.into_no_null_iter().any(|v| v == act.id) {
+                        return Ok(());
+                    }
+                }
+            }
+            df.vstack_mut(&new_df)?;
+            let file = File::create(&path)?;
+            ParquetWriter::new(file).finish(&mut df)?;
+        } else {
+            let file = File::create(&path)?;
+            ParquetWriter::new(file).finish(&mut new_df)?;
+        }
         Ok(())
     }
 }

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -1,6 +1,6 @@
 use actix_web::{test, App};
 use abcy_data::storage::Storage;
-use abcy_data::api::{list_activities, list_raw_files}; // we need to import for service
+use abcy_data::api::{list_activities, list_raw_files, download_fit, fit_details};
 use tempfile::tempdir;
 
 #[actix_rt::test]
@@ -23,4 +23,24 @@ async fn list_raw_files_returns_empty() {
     let req = test::TestRequest::get().uri("/raw").to_request();
     let resp: Vec<serde_json::Value> = test::call_and_read_body_json(&app, req).await;
     assert!(resp.is_empty());
+}
+
+#[actix_rt::test]
+async fn download_fit_missing_returns_404() {
+    let dir = tempdir().unwrap();
+    let storage = Storage::new(dir.path());
+    let app = test::init_service(App::new().app_data(actix_web::web::Data::new(storage)).service(download_fit)).await;
+    let req = test::TestRequest::get().uri("/fit/1").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 404);
+}
+
+#[actix_rt::test]
+async fn fit_details_missing_returns_404() {
+    let dir = tempdir().unwrap();
+    let storage = Storage::new(dir.path());
+    let app = test::init_service(App::new().app_data(actix_web::web::Data::new(storage)).service(fit_details)).await;
+    let req = test::TestRequest::get().uri("/fit/1/details").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 404);
 }

--- a/tests/storage_tests.rs
+++ b/tests/storage_tests.rs
@@ -1,4 +1,4 @@
-use abcy_data::{storage::Storage, fit_parser::DataPoint};
+use abcy_data::{storage::Storage, fit_parser::DataPoint, strava::ActivitySummary};
 use tempfile::tempdir;
 
 #[test]
@@ -12,4 +12,15 @@ fn save_activity_creates_parquet() {
     let file = dir.path().join("42.parquet");
     assert!(file.exists());
     assert!(storage.has_activity(42));
+}
+
+#[test]
+fn save_metadata_creates_file() {
+    let dir = tempdir().unwrap();
+    let storage = Storage::new(dir.path());
+    let summary = ActivitySummary { id: 1, name: "Ride".into(), start_date: "2023-01-01".into(), distance: 1.0 };
+    storage.save_metadata(&summary).unwrap();
+    let file = dir.path().join("metadata.parquet");
+    assert!(file.exists());
+    assert!(storage.has_metadata(1));
 }

--- a/tests/sync_tests.rs
+++ b/tests/sync_tests.rs
@@ -33,7 +33,8 @@ async fn sync_downloads_missing_activity() {
     let storage = Storage::new(dir.path());
     let client = DummyClient::new();
     sync::sync_latest(&client, &storage, 10).await.unwrap();
-    assert!(dir.path().join("99.fit").exists());
+    assert!(dir.path().join("raw/99.fit").exists());
+    assert!(dir.path().join("metadata.parquet").exists());
     assert_eq!(*client.downloads.lock().unwrap(), 1);
 }
 
@@ -41,6 +42,7 @@ async fn sync_downloads_missing_activity() {
 async fn sync_skips_existing_activity() {
     let dir = tempdir().unwrap();
     let storage = Storage::new(dir.path());
+    std::fs::create_dir_all(dir.path().join("raw")).unwrap();
     std::fs::write(dir.path().join("99.parquet"), b"x").unwrap();
     let client = DummyClient::new();
     sync::sync_latest(&client, &storage, 10).await.unwrap();


### PR DESCRIPTION
## Summary
- store ride metadata in a parquet file
- avoid re-downloading fit files if already present
- expose endpoints to download fit files and inspect them
- update API documentation and agent instructions
- adjust tests for new behavior

## Testing
- `cargo test` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_685b2d645a04832081a158d64591906b