### PR TITLE
Improve error messaging for missing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project synchronizes cycling activities from Strava and exposes a simple HT
 
 ## Configuration
 
-Configuration is read from `config.toml` instead of environment variables. A minimal example:
+Configuration is read from `config.toml` instead of environment variables. A minimal example is provided in `config.example.toml`. Copy this file to `config.toml` and fill in your credentials:
 
 ```toml
 [strava]

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,10 @@
+[strava]
+client_id = "12345"
+client_secret = "secret"
+refresh_token = "<refresh token>"
+token_path = "./token.json"      # cached access token
+
+[storage]
+data_dir = "./data"
+download_count = 10
+user = "athlete1"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use std::fs;
+use anyhow::Context;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Strava {
@@ -30,8 +31,11 @@ fn default_base_url() -> String {
 
 impl Config {
     pub fn load(path: &str) -> anyhow::Result<Self> {
-        let text = fs::read_to_string(path)?;
-        let cfg: Self = toml::from_str(&text)?;
+        tracing::info!("loading configuration from {}", path);
+        let text = fs::read_to_string(path)
+            .with_context(|| format!("config file '{}' not found", path))?;
+        let cfg: Self = toml::from_str(&text)
+            .context("failed to parse TOML in config file")?;
         Ok(cfg)
     }
 }


### PR DESCRIPTION
## Summary
- log the configuration file path during startup
- provide better error context when the config file is missing or malformed
- add `config.example.toml` and mention it in the README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685c6476a5d48320acef1e819848c6e5