### PR TITLE
Auto authorize if no refresh token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "async-trait",
+ "chrono",
  "dotenvy",
  "mockito",
  "reqwest",
@@ -251,6 +252,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +423,20 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "chunked_transfer"
@@ -902,6 +932,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1282,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "objc"
@@ -2240,6 +2303,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "abcy-data"
 version = "0.1.0"
 edition = "2021"
+default-run = "abcy-data"
 
 [dependencies]
 actix-web = "4"
@@ -14,6 +15,7 @@ toml = "0.8"
 tokio = { version = "1", features = ["macros","rt-multi-thread","fs","time"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+chrono = { version = "0.4", features = ["clock"] }
 dotenvy = "0.15"
 anyhow = "1.0"
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Configuration is read from `config.toml` instead of environment variables. A min
 [strava]
 client_id = "12345"
 client_secret = "secret"
-refresh_token = "<refresh token>"
-token_path = "./token.json"      # cached access token
+# optional refresh token obtained during authorization
+refresh_token = ""
+token_path = "./token.json"      # cached access token and expiry
 
 [storage]
 data_dir = "./data"
@@ -24,9 +25,12 @@ download_count = 10
 user = "athlete1"
 ```
 
-When the Strava API returns a `401` the application automatically refreshes the
-token using the stored `refresh_token` and writes the new credentials to
-`token_path`.
+If the cached token has expired or the Strava API returns a `401`, the
+application automatically refreshes it using the stored `refresh_token`.
+The new access token, refresh token and expiry time are written to `token_path`
+and the expiry is logged. If no refresh token is provided the server will open
+a browser on startup to complete the OAuth flow and store the returned
+credentials.
 
 ### Obtaining Strava Tokens
 
@@ -58,14 +62,18 @@ token using the stored `refresh_token` and writes the new credentials to
        -d grant_type=authorization_code
    ```
 
-   The JSON response contains `refresh_token` which should be stored in your
-   configuration file.
+  The JSON response contains `refresh_token` which can be stored in your
+  configuration file. This step is optional because running the server with an
+  empty `refresh_token` will trigger the interactive authorization flow.
 
 ## Running
 
 ```bash
 cargo run
 ```
+
+The `default-run` target is configured, so this command starts the main
+`abcy-data` server without needing `--bin`.
 
 On startup the app will:
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,8 +1,9 @@
 [strava]
 client_id = "12345"
 client_secret = "secret"
-refresh_token = "<refresh token>"
-token_path = "./token.json"      # cached access token
+# optional refresh token obtained via authorization
+refresh_token = ""
+token_path = "./token.json"      # cached access token and expiry
 
 [storage]
 data_dir = "./data"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,15 +1,17 @@
 use crate::utils::Config;
-use reqwest::{Client, Method};
-use serde::Deserialize;
+use anyhow::Context;
+use reqwest::{Client, Method, Url};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 #[derive(Clone)]
 pub struct Auth {
     client: Client,
     pub cfg: Config,
-    token: Arc<Mutex<Option<String>>>,
+    token: Arc<Mutex<Option<Token>>>,
 }
 
 impl Auth {
@@ -17,49 +19,128 @@ impl Auth {
         Self { client: Client::new(), cfg, token: Arc::new(Mutex::new(None)) }
     }
 
-    async fn load_token(&self) -> Option<String> {
+    async fn load_token(&self) -> Option<Token> {
         let path = &self.cfg.strava.token_path;
         match tokio::fs::read_to_string(path).await {
-            Ok(t) => serde_json::from_str::<Token>(&t).ok().map(|t| t.access_token),
+            Ok(t) => serde_json::from_str::<Token>(&t).ok(),
             Err(_) => None,
         }
     }
 
-    async fn save_token(&self, token: &str) -> anyhow::Result<()> {
+    async fn save_token(&self, token: &Token) -> anyhow::Result<()> {
         let path = &self.cfg.strava.token_path;
-        let data = serde_json::to_string(&Token { access_token: token.into() })?;
+        let data = serde_json::to_string(token)?;
         tokio::fs::write(path, data).await?;
         Ok(())
     }
 
     async fn ensure_token(&self) -> anyhow::Result<String> {
-        if let Some(t) = self.token.lock().await.clone() {
-            return Ok(t);
+        if let Some(tok) = self.token.lock().await.clone() {
+            if tok.expires_at > chrono::Utc::now().timestamp() {
+                return Ok(tok.access_token.clone());
+            }
+            return Ok(self.refresh_token_with(&tok.refresh_token).await?.access_token);
         }
-        if let Some(t) = self.load_token().await { 
-            *self.token.lock().await = Some(t.clone());
-            return Ok(t);
+        if let Some(tok) = self.load_token().await {
+            if tok.expires_at > chrono::Utc::now().timestamp() {
+                *self.token.lock().await = Some(tok.clone());
+                return Ok(tok.access_token);
+            }
+            return Ok(self.refresh_token_with(&tok.refresh_token).await?.access_token);
         }
-        let t = self.refresh_token().await?;
-        Ok(t)
+        if let Some(ref rt) = self.cfg.strava.refresh_token {
+            return Ok(self.refresh_token_with(rt).await?.access_token);
+        }
+        let tok = self.authorize().await?;
+        Ok(tok.access_token)
     }
 
-    pub async fn refresh_token(&self) -> anyhow::Result<String> {
+    async fn refresh_token_with(&self, refresh_token: &str) -> anyhow::Result<Token> {
         #[derive(Deserialize)]
-        struct Resp { access_token: String }
-        let resp = self.client.post(format!("{}/oauth/token", self.cfg.base_url.trim_end_matches("/api/v3")))
+        struct Resp { access_token: String, refresh_token: String, expires_at: i64 }
+        let resp = self
+            .client
+            .post(format!("{}/oauth/token", self.cfg.base_url.trim_end_matches("/api/v3")))
             .form(&[
                 ("client_id", self.cfg.strava.client_id.as_str()),
                 ("client_secret", self.cfg.strava.client_secret.as_str()),
                 ("grant_type", "refresh_token"),
-                ("refresh_token", self.cfg.strava.refresh_token.as_str()),
+                ("refresh_token", refresh_token),
             ])
             .send()
             .await?;
         let status = resp.status();
-        if !status.is_success() { warn!(%status, "token refresh failed"); anyhow::bail!("refresh failed") }
-        let token = resp.json::<Resp>().await?.access_token;
-        info!("refreshed strava token");
+        if !status.is_success() {
+            warn!(%status, "token refresh failed");
+            anyhow::bail!("refresh failed")
+        }
+        let resp = resp.json::<Resp>().await?;
+        info!(expires_at = resp.expires_at, "refreshed strava token");
+        let token = Token {
+            access_token: resp.access_token,
+            refresh_token: resp.refresh_token,
+            expires_at: resp.expires_at,
+        };
+        *self.token.lock().await = Some(token.clone());
+        self.save_token(&token).await?;
+        Ok(token)
+    }
+
+    async fn authorize(&self) -> anyhow::Result<Token> {
+        let url = format!(
+            "https://www.strava.com/oauth/authorize?client_id={}&response_type=code&redirect_uri=http://localhost:8080&approval_prompt=auto&scope=activity:read_all",
+            self.cfg.strava.client_id
+        );
+        webbrowser::open(&url).context("failed to open browser")?;
+        info!("Opened browser to URL");
+
+        let server = tiny_http::Server::http("0.0.0.0:8080").map_err(|e| {
+            anyhow::anyhow!("failed to bind to localhost:8080 (is it already running?): {}", e)
+        })?;
+        let request = server.recv().context("failed to receive request")?;
+        let full_url = format!("http://localhost:8080{}", request.url());
+        let parsed = Url::parse(&full_url)?;
+        let params: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+        let code = params
+            .get("code")
+            .cloned()
+            .context("missing code in redirect")?;
+        info!("Received redirect with code");
+
+        let mut response = tiny_http::Response::from_string(
+            "<html><body><h2>Authorization complete. You may close this window.</h2></body></html>",
+        );
+        response.add_header(tiny_http::Header::from_bytes("Content-Type", "text/html").unwrap());
+        let _ = request.respond(response);
+
+        #[derive(Deserialize)]
+        struct Resp { access_token: String, refresh_token: String, expires_at: i64 }
+        let resp = self
+            .client
+            .post("https://www.strava.com/api/v3/oauth/token")
+            .form(&[
+                ("client_id", self.cfg.strava.client_id.as_str()),
+                ("client_secret", self.cfg.strava.client_secret.as_str()),
+                ("code", &code),
+                ("grant_type", "authorization_code"),
+            ])
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            error!(%status, "token request failed");
+            anyhow::bail!("token exchange failed")
+        }
+        let tok = resp.json::<Resp>().await?;
+        info!("Token exchange successful");
+        info!("Access token: {}", tok.access_token);
+        info!("Refresh token: {}", tok.refresh_token);
+        info!("Expires at (unix): {}", tok.expires_at);
+        let token = Token {
+            access_token: tok.access_token,
+            refresh_token: tok.refresh_token,
+            expires_at: tok.expires_at,
+        };
         *self.token.lock().await = Some(token.clone());
         self.save_token(&token).await?;
         Ok(token)
@@ -71,8 +152,19 @@ impl Auth {
         let mut resp = req.try_clone().unwrap().send().await?;
         if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
             warn!("401 from Strava, refreshing token");
-            let token = self.refresh_token().await?;
-            resp = self.client.request(method, url).bearer_auth(&token).send().await?;
+            let token = if let Some(tok) = self.token.lock().await.clone() {
+                self.refresh_token_with(&tok.refresh_token).await?
+            } else if let Some(ref rt) = self.cfg.strava.refresh_token {
+                self.refresh_token_with(rt).await?
+            } else {
+                self.authorize().await?
+            };
+            resp = self
+                .client
+                .request(method, url)
+                .bearer_auth(&token.access_token)
+                .send()
+                .await?;
         }
         Ok(resp)
     }
@@ -83,5 +175,9 @@ impl Auth {
     }
 }
 
-#[derive(Deserialize, serde::Serialize)]
-struct Token { access_token: String }
+#[derive(Clone, Deserialize, Serialize)]
+struct Token {
+    access_token: String,
+    refresh_token: String,
+    expires_at: i64,
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,7 +6,7 @@ use anyhow::Context;
 pub struct Strava {
     pub client_id: String,
     pub client_secret: String,
-    pub refresh_token: String,
+    pub refresh_token: Option<String>,
     pub token_path: String,
 }
 

--- a/tests/auth_refresh.rs
+++ b/tests/auth_refresh.rs
@@ -4,11 +4,10 @@ use mockito::Server;
 #[tokio::test(flavor = "current_thread")]
 async fn refresh_on_401() {
     let mut server = Server::new_async().await;
-    let _m1 = server.mock("GET", "/athlete/activities").with_status(401).create();
     let _refresh = server
         .mock("POST", "/oauth/token")
         .with_status(200)
-        .with_body("{\"access_token\": \"newtok\"}")
+        .with_body("{\"access_token\": \"newtok\", \"refresh_token\": \"newref\", \"expires_at\": 123}")
         .create();
     let _m2 = server
         .mock("GET", "/athlete/activities")
@@ -20,13 +19,13 @@ async fn refresh_on_401() {
         strava: Strava {
             client_id: "id".into(),
             client_secret: "secret".into(),
-            refresh_token: "refresh".into(),
+            refresh_token: Some("refresh".into()),
             token_path: "token.json".into(),
         },
         storage: Storage { data_dir: "tmp".into(), download_count: 1, user: "t".into() },
         base_url: server.url(),
     };
-    tokio::fs::write("token.json", "{\"access_token\":\"expired\"}").await.unwrap();
+    tokio::fs::write("token.json", "{\"access_token\":\"expired\",\"refresh_token\":\"rt\",\"expires_at\":0}").await.unwrap();
     let auth = Auth::new(cfg);
     let _ = auth.get_json::<serde_json::Value>(&format!("{}/athlete/activities", server.url())).await.unwrap();
     assert!(_refresh.matched());


### PR DESCRIPTION
## Summary
- allow running the server without a refresh token
- attempt interactive OAuth when no refresh token is available
- store refresh token alongside access token and expiry
- document automatic authorization and optional refresh token

## Testing
- `cargo test --quiet`
- `cargo check --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685c81f1d44483209b516648692690a4