### PR TITLE
Skip already downloaded activities

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -8,6 +8,11 @@ pub async fn download_latest(auth: &Auth, storage: &Storage, count: usize) -> an
     info!("Requesting activity list: {}", url);
     let acts: Vec<ActivityHeader> = auth.get_json(&url).await?;
     for summary in acts {
+        let year = &summary.start_date[..4];
+        if storage.activity_exists(year, summary.id).await {
+            info!(id = summary.id, "activity already downloaded");
+            continue;
+        }
         info!(id = summary.id, name = %summary.name, "download activity");
         let meta_url = format!("{}/activities/{}", auth.cfg.base_url, summary.id);
         info!("Requesting activity metadata: {}", meta_url);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -30,6 +30,11 @@ impl Storage {
         Ok(())
     }
 
+    pub async fn activity_exists(&self, year: &str, id: u64) -> bool {
+        let path = self.activity_dir(year, id).join("meta.json.zst");
+        fs::metadata(path).await.is_ok()
+    }
+
     async fn write_zstd<P: AsRef<Path>>(&self, path: P, value: &serde_json::Value) -> anyhow::Result<()> {
         let data = serde_json::to_vec(value)?;
         let compressed = encode_all(&data[..], 0)?;

--- a/tests/activity_exists.rs
+++ b/tests/activity_exists.rs
@@ -1,0 +1,19 @@
+use abcy_data::{storage::Storage, utils::Storage as StorageCfg};
+use serde_json::json;
+use tempfile::tempdir;
+
+fn make_storage() -> Storage {
+    let dir = tempdir().unwrap();
+    let cfg = StorageCfg { data_dir: dir.path().to_str().unwrap().into(), download_count: 1, user: "t".into() };
+    Storage::new(&cfg)
+}
+
+#[tokio::test]
+async fn activity_exists_check() {
+    let storage = make_storage();
+    assert!(!storage.activity_exists("2024", 1).await);
+    let meta = json!({"id":1,"name":"ride","start_date":"2024-01-01","distance":1.0});
+    let streams = json!({"time":[1,2,3]});
+    storage.save(&meta, &streams).await.unwrap();
+    assert!(storage.activity_exists("2024", 1).await);
+}


### PR DESCRIPTION
## Summary
- add `activity_exists` helper to check for stored activities
- skip download when an activity already exists
- test existence check

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685dcd1f7ec88320a530d767462e6f91