### PR TITLE
Add power stream to activity details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ The server listens on `localhost:8080` by default.
 ## HTTP endpoints
 
 - `GET /activities` – list downloaded activities (id, name, date, distance)
-- `GET /activity/{id}` – full metadata and streams for an activity
+- `GET /activity/{id}` – full metadata and streams (time and power) for an activity
 - `GET /files` – recursive listing of stored files
 - `POST /webhook` – Strava webhook used to trigger immediate downloads
 
@@ -43,7 +43,7 @@ The included `abcy-data.postman_collection.json` can be imported into Postman fo
 ## Modules
 
 - **auth** – handles Strava OAuth and token refresh logic
-- **fetch** – downloads activity metadata and streams
+- **fetch** – downloads activity metadata and streams (time and power)
 - **storage** – writes and reads compressed JSON files on disk
 - **web** – exposes the HTTP API routes
 - **schema** – shared structs for metadata and stream payloads

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # abcy-data
 
-This project synchronizes cycling activities from Strava and exposes a simple HTTP API.  Activity metadata and data streams are stored as compressed JSON files for further analysis.
+This project synchronizes cycling activities from Strava and exposes a simple HTTP API.  Activity metadata and data streams—including power output—are stored as compressed JSON files for further analysis.
 
 ## Requirements
 
@@ -75,14 +75,15 @@ The `default-run` target is configured, so this command starts the main
 On startup the app will:
 
 1. Query your most recent activities (count configured by `download_count`).
-2. Fetch metadata and data streams for each new activity and store them under
-   `DATA_DIR/<user>/<year>/<id>/` as `meta.json.zst` and `streams.json.zst`.
+2. Fetch metadata and data streams for each new activity (time and power when
+   available) and store them under `DATA_DIR/<user>/<year>/<id>/` as
+   `meta.json.zst` and `streams.json.zst`.
 3. Start an HTTP server on `localhost:8080`.
 
 ### API Endpoints
 
 - `GET /activities?count=n` – list activities ordered by newest first. If `count` is omitted all headers are returned.
-- `GET /activity/{id}` – full metadata and streams for an activity.
+- `GET /activity/{id}` – full metadata and streams (time and power) for an activity.
 - `GET /files` – recursive listing of everything under `DATA_DIR`.
 - `GET /raw/{path}` – return a stored file by relative path.
 - `POST /webhook` – Strava webhook endpoint used to fetch new data immediately.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -11,15 +11,26 @@ pub struct ActivityHeader {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActivityDetail {
     pub meta: serde_json::Value,
-    pub streams: serde_json::Value,
+    pub streams: ParsedStreams,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ParsedStreams {
     pub time: Vec<i64>,
+    /// Power data in watts if available
+    pub power: Vec<i64>,
 }
 
 pub fn parse_streams(v: &serde_json::Value) -> Option<ParsedStreams> {
     let time = v.get("time")?.get("data")?.as_array()?;
-    Some(ParsedStreams { time: time.iter().map(|x| x.as_i64().unwrap_or(0)).collect() })
+    let power = v
+        .get("watts")
+        .and_then(|p| p.get("data"))
+        .and_then(|d| d.as_array())
+        .map(|arr| arr.iter().map(|x| x.as_i64().unwrap_or(0)).collect())
+        .unwrap_or_else(Vec::new);
+    Some(ParsedStreams {
+        time: time.iter().map(|x| x.as_i64().unwrap_or(0)).collect(),
+        power,
+    })
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::schema::{ActivityHeader, ActivityDetail};
+use crate::schema::{ActivityHeader, ActivityDetail, ParsedStreams};
 use crate::utils::Storage as StorageCfg;
 use std::path::{Path, PathBuf};
 use tokio::fs;
@@ -72,7 +72,9 @@ impl Storage {
             let dir = year.path().join(id.to_string());
             if fs::metadata(&dir).await.is_ok() {
                 let meta = self.read_zstd(dir.join("meta.json.zst")).await?;
-                let streams = self.read_zstd(dir.join("streams.json.zst")).await?;
+                let raw_streams = self.read_zstd(dir.join("streams.json.zst")).await?;
+                let streams = crate::schema::parse_streams(&raw_streams)
+                    .unwrap_or(ParsedStreams { time: vec![], power: vec![] });
                 return Ok(ActivityDetail { meta, streams });
             }
         }

--- a/tests/stream_parse.rs
+++ b/tests/stream_parse.rs
@@ -5,5 +5,18 @@ use serde_json::json;
 fn parse_time_stream() {
     let v = json!({"time": {"data": [1,2,3]}});
     let parsed = parse_streams(&v).unwrap();
-    assert_eq!(parsed, ParsedStreams { time: vec![1,2,3] });
+    assert_eq!(
+        parsed,
+        ParsedStreams {
+            time: vec![1, 2, 3],
+            power: vec![],
+        }
+    );
+}
+
+#[test]
+fn parse_power_stream() {
+    let v = json!({"time": {"data": [0]}, "watts": {"data": [100, 200]}});
+    let parsed = parse_streams(&v).unwrap();
+    assert_eq!(parsed.power, vec![100, 200]);
 }

--- a/tests/zstd_roundtrip.rs
+++ b/tests/zstd_roundtrip.rs
@@ -1,4 +1,4 @@
-use abcy_data::{storage::Storage, utils::Storage as StorageCfg};
+use abcy_data::{storage::Storage, utils::Storage as StorageCfg, schema::ParsedStreams};
 use serde_json::json;
 use tempfile::tempdir;
 
@@ -12,9 +12,12 @@ fn make_storage() -> Storage {
 async fn round_trip() {
     let storage = make_storage();
     let meta = json!({"id":1,"name":"ride","start_date":"2024-01-01","distance":1.0});
-    let streams = json!({"time":[1,2,3]});
+    let streams = json!({"time": {"data": [1,2,3]}, "watts": {"data": [10,20]}});
     storage.save(&meta, &streams).await.unwrap();
     let act = storage.load_activity(1).await.unwrap();
     assert_eq!(act.meta, meta);
-    assert_eq!(act.streams, streams);
+    assert_eq!(
+        act.streams,
+        ParsedStreams { time: vec![1,2,3], power: vec![10,20] }
+    );
 }


### PR DESCRIPTION
## Summary
- parse power output when loading streams
- return parsed streams with power from activity details
- document power streams in README
- test round-trip with power data

## Testing
- `cargo test -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_685dcd06b354832082d9f7d81ab25d2b