### PR TITLE
Add additional summary metrics

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -22,6 +22,14 @@ pub struct ActivitySummary {
     pub distance: f64,
     pub duration: i64,
     pub average_power: Option<f64>,
+    /// Average speed in meters per second if available
+    pub average_speed: Option<f64>,
+    /// Number of personal records from segments if available
+    pub pr_count: Option<i64>,
+    /// Average heart rate in bpm if available
+    pub average_heartrate: Option<f64>,
+    /// Summary polyline of the activity map if available
+    pub summary_polyline: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -29,6 +37,8 @@ pub struct ParsedStreams {
     pub time: Vec<i64>,
     /// Power data in watts if available
     pub power: Vec<i64>,
+    /// Heart rate data in bpm if available
+    pub heartrate: Vec<i64>,
 }
 
 pub fn parse_streams(v: &serde_json::Value) -> Option<ParsedStreams> {
@@ -39,8 +49,15 @@ pub fn parse_streams(v: &serde_json::Value) -> Option<ParsedStreams> {
         .and_then(|d| d.as_array())
         .map(|arr| arr.iter().map(|x| x.as_i64().unwrap_or(0)).collect())
         .unwrap_or_else(Vec::new);
+    let heartrate = v
+        .get("heartrate")
+        .and_then(|p| p.get("data"))
+        .and_then(|d| d.as_array())
+        .map(|arr| arr.iter().map(|x| x.as_i64().unwrap_or(0)).collect())
+        .unwrap_or_else(Vec::new);
     Some(ParsedStreams {
         time: time.iter().map(|x| x.as_i64().unwrap_or(0)).collect(),
         power,
+        heartrate,
     })
 }

--- a/tests/activity_summary.rs
+++ b/tests/activity_summary.rs
@@ -11,11 +11,29 @@ fn make_storage() -> Storage {
 #[tokio::test]
 async fn summary_computation() {
     let storage = make_storage();
-    let meta = json!({"id":1,"name":"ride","start_date":"2024-01-01","distance":1.0,"elapsed_time":30});
-    let streams = json!({"time": {"data": [0,10,20,30]}, "watts": {"data": [100,150,200]}});
+    let meta = json!({
+        "id":1,
+        "name":"ride",
+        "start_date":"2024-01-01",
+        "distance":1.0,
+        "elapsed_time":30,
+        "average_speed":0.033,
+        "pr_count":2,
+        "average_heartrate":95.0,
+        "map": {"summary_polyline":"xyz"}
+    });
+    let streams = json!({
+        "time": {"data": [0,10,20,30]},
+        "watts": {"data": [100,150,200]},
+        "heartrate": {"data": [90,100,95,95]}
+    });
     storage.save(&meta, &streams).await.unwrap();
     let summary = storage.load_activity_summary(1).await.unwrap();
     assert_eq!(summary.id, 1);
     assert_eq!(summary.duration, 30);
     assert!(summary.average_power.unwrap() > 0.0);
+    assert!(summary.average_speed.unwrap() > 0.0);
+    assert_eq!(summary.pr_count, Some(2));
+    assert!(summary.average_heartrate.unwrap() > 0.0);
+    assert_eq!(summary.summary_polyline, Some("xyz".into()));
 }

--- a/tests/stream_parse.rs
+++ b/tests/stream_parse.rs
@@ -10,13 +10,15 @@ fn parse_time_stream() {
         ParsedStreams {
             time: vec![1, 2, 3],
             power: vec![],
+            heartrate: vec![],
         }
     );
 }
 
 #[test]
 fn parse_power_stream() {
-    let v = json!({"time": {"data": [0]}, "watts": {"data": [100, 200]}});
+    let v = json!({"time": {"data": [0]}, "watts": {"data": [100, 200]}, "heartrate": {"data": [90, 95]}});
     let parsed = parse_streams(&v).unwrap();
     assert_eq!(parsed.power, vec![100, 200]);
+    assert_eq!(parsed.heartrate, vec![90, 95]);
 }

--- a/tests/zstd_roundtrip.rs
+++ b/tests/zstd_roundtrip.rs
@@ -12,12 +12,12 @@ fn make_storage() -> Storage {
 async fn round_trip() {
     let storage = make_storage();
     let meta = json!({"id":1,"name":"ride","start_date":"2024-01-01","distance":1.0});
-    let streams = json!({"time": {"data": [1,2,3]}, "watts": {"data": [10,20]}});
+    let streams = json!({"time": {"data": [1,2,3]}, "watts": {"data": [10,20]}, "heartrate": {"data": [80,81,82]}});
     storage.save(&meta, &streams).await.unwrap();
     let act = storage.load_activity(1).await.unwrap();
     assert_eq!(act.meta, meta);
     assert_eq!(
         act.streams,
-        ParsedStreams { time: vec![1,2,3], power: vec![10,20] }
+        ParsedStreams { time: vec![1,2,3], power: vec![10,20], heartrate: vec![80,81,82] }
     );
 }


### PR DESCRIPTION
## Summary
- extend `ActivitySummary` with speed, PR count, heartrate, and polyline
- include heartrate stream parsing
- compute new metrics in `Storage::load_activity_summary`
- update unit tests

## Testing
- `cargo test --locked --all-targets -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_685de3863ea083208bb0ff6a967e512e