### PR TITLE
Add FTP history endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,12 @@ The server listens on `localhost:8080` by default.
 - `GET /activities` – list downloaded activities (id, name, date, distance)
 - `GET /activity/{id}` – full metadata and streams (time and power) for an activity
 - `GET /files` – recursive listing of stored files
+- `GET /ftp` – return the current FTP value
+- `GET /ftp/history?count=n` – return FTP history ordered by newest first, optionally limited to `n` entries
+- `POST /ftp` – append a new FTP value
 - `POST /webhook` – Strava webhook used to trigger immediate downloads
+
+Activity summaries now include normalized power (NP), intensity factor (IF) and training stress score (TSS) calculated using the stored FTP value.
 
 ## Python usage
 

--- a/README.md
+++ b/README.md
@@ -77,16 +77,21 @@ On startup the app will:
 1. Query your most recent activities (count configured by `download_count`).
 2. Fetch metadata and data streams for each new activity (time and power when
    available) and store them under `DATA_DIR/<user>/<year>/<id>/` as
-   `meta.json.zst` and `streams.json.zst`.
+   `meta.json.zst` and `streams.json.zst`. During this step the service
+   computes normalized power (NP), intensity factor (IF) and training stress
+   score (TSS) using the current FTP value and writes them into `meta.json.zst`.
 3. Start an HTTP server on `localhost:8080`.
 
 ### API Endpoints
 
 - `GET /activities?count=n` – list activities ordered by newest first. If `count` is omitted all headers are returned.
 - `GET /activity/{id}` – full metadata and streams (time and power) for an activity.
-- `GET /activity/{id}/summary` – small summary with duration and average power.
+- `GET /activity/{id}/summary` – small summary with duration, power and training metrics.
 - `GET /files` – recursive listing of everything under `DATA_DIR`.
 - `GET /raw/{path}` – return a stored file by relative path.
+- `GET /ftp` – return the current FTP value.
+- `GET /ftp/history?count=n` – return the stored FTP history ordered by newest first, optionally limited to `n` items.
+- `POST /ftp` – append a new FTP value.
 - `POST /webhook` – Strava webhook endpoint used to fetch new data immediately.
 
 A Postman collection `abcy-data.postman_collection.json` is included to help
@@ -102,9 +107,10 @@ DATA_DIR/
       <id>/
         meta.json.zst
         streams.json.zst
+    ftp.json
 ```
 
-Metadata and streams are encoded with `serde_json` and compressed using zstd.
+Metadata and streams are encoded with `serde_json` and compressed using zstd. The `ftp.json` file stores your Functional Threshold Power history used to compute IF and TSS.
 
 ## Adding Another User
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -30,6 +30,12 @@ pub struct ActivitySummary {
     pub average_heartrate: Option<f64>,
     /// Summary polyline of the activity map if available
     pub summary_polyline: Option<String>,
+    /// Normalized power in watts if available
+    pub normalized_power: Option<f64>,
+    /// Intensity factor relative to FTP if available
+    pub intensity_factor: Option<f64>,
+    /// Training stress score if available
+    pub training_stress_score: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -42,7 +48,12 @@ pub struct ParsedStreams {
 }
 
 pub fn parse_streams(v: &serde_json::Value) -> Option<ParsedStreams> {
-    let time = v.get("time")?.get("data")?.as_array()?;
+    let time_val = v.get("time")?;
+    let time = if time_val.is_object() {
+        time_val.get("data")?.as_array()?
+    } else {
+        time_val.as_array()?
+    };
     let power = v
         .get("watts")
         .or_else(|| v.get("power"))

--- a/tests/dragonride_summary.rs
+++ b/tests/dragonride_summary.rs
@@ -18,4 +18,10 @@ async fn dragonride_average_power() {
     storage.save(meta, streams).await.unwrap();
     let summary = storage.load_activity_summary(meta["id"].as_u64().unwrap()).await.unwrap();
     assert_eq!(summary.average_power.unwrap().round() as i64, 160);
+    let np = summary.normalized_power.unwrap();
+    let ifv = summary.intensity_factor.unwrap();
+    let tss = summary.training_stress_score.unwrap();
+    assert!((np - 170.09).abs() < 0.1);
+    assert!((ifv - 0.7087).abs() < 0.001);
+    assert!((tss - 443.18).abs() < 1.0);
 }

--- a/tests/ftp.rs
+++ b/tests/ftp.rs
@@ -1,0 +1,30 @@
+use abcy_data::{storage::Storage, utils::Storage as StorageCfg};
+use tempfile::tempdir;
+
+fn make_storage() -> Storage {
+    let dir = tempdir().unwrap();
+    let cfg = StorageCfg { data_dir: dir.path().to_str().unwrap().into(), download_count: 1, user: "t".into() };
+    Storage::new(&cfg)
+}
+
+#[tokio::test]
+async fn ftp_history_update() {
+    let storage = make_storage();
+    // first call creates default entry
+    let hist1 = storage.get_ftp_history().await.unwrap();
+    assert_eq!(hist1.len(), 1);
+    assert_eq!(hist1[0].ftp, 240.0);
+
+    // set new ftp
+    storage.set_ftp(250.0).await.unwrap();
+    let current = storage.current_ftp().await.unwrap();
+    assert_eq!(current, 250.0);
+
+    let hist2 = storage.get_ftp_history().await.unwrap();
+    assert_eq!(hist2.len(), 2);
+    assert_eq!(hist2.last().unwrap().ftp, 250.0);
+
+    let recent = storage.ftp_history(Some(1)).await.unwrap();
+    assert_eq!(recent.len(), 1);
+    assert_eq!(recent[0].ftp, 250.0);
+}

--- a/tests/zstd_roundtrip.rs
+++ b/tests/zstd_roundtrip.rs
@@ -15,7 +15,10 @@ async fn round_trip() {
     let streams = json!({"time": {"data": [1,2,3]}, "watts": {"data": [10,20]}, "heartrate": {"data": [80,81,82]}});
     storage.save(&meta, &streams).await.unwrap();
     let act = storage.load_activity(1).await.unwrap();
-    assert_eq!(act.meta, meta);
+    assert_eq!(act.meta["id"], meta["id"]);
+    assert_eq!(act.meta["name"], meta["name"]);
+    assert_eq!(act.meta["start_date"], meta["start_date"]);
+    assert_eq!(act.meta["distance"], meta["distance"]);
     assert_eq!(
         act.streams,
         ParsedStreams { time: vec![1,2,3], power: vec![10,20], heartrate: vec![80,81,82] }


### PR DESCRIPTION
## Summary
- provide new `GET /ftp` for latest FTP and a `/ftp/history` endpoint
- write ftp history even if the base directory doesn't exist
- expose new endpoints in README and AGENTS instructions
- register endpoints in the web server
- test ftp storage features

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861dca060ec8320b1916595dd202bc5