### PR TITLE
Add weight docs and wkg test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@ The server listens on `localhost:8080` by default.
 - `GET /ftp` – return the current FTP value
 - `GET /ftp/history?count=n` – return FTP history ordered by newest first, optionally limited to `n` entries
 - `POST /ftp` – append a new FTP value
+- `GET /weight` – return the current weight in kilograms
+- `GET /weight/history?count=n` – return weight history ordered by newest first, optionally limited to `n` entries
+- `POST /weight` – append a new weight value
+- `GET /wkg` – return watts per kilogram using the current FTP and weight
+- `GET /wkg/history?count=n` – return stored watts per kilogram history
 - `POST /webhook` – Strava webhook used to trigger immediate downloads
 
 Activity summaries now include normalized power (NP), intensity factor (IF) and training stress score (TSS) calculated using the stored FTP value.
@@ -57,3 +62,5 @@ The included `abcy-data.postman_collection.json` can be imported into Postman fo
 Downloaded activities are stored under `DATA_DIR/<user>/<year>/<id>` where
 `<user>` is configured in `config.toml`. Each directory contains
 `meta.json.zst` and `streams.json.zst`.
+The `<user>` directory also stores `ftp.json`, `weight.json` and
+`wkg.json` tracking your FTP, weight and watts-per-kilogram history.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ On startup the app will:
 - `GET /ftp` – return the current FTP value.
 - `GET /ftp/history?count=n` – return the stored FTP history ordered by newest first, optionally limited to `n` items.
 - `POST /ftp` – append a new FTP value.
+- `GET /weight` – return the current weight in kilograms.
+- `GET /weight/history?count=n` – return weight history ordered by newest first, optionally limited to `n` items.
+- `POST /weight` – append a new weight value.
+- `GET /wkg` – return the current watts per kilogram using FTP and weight.
+- `GET /wkg/history?count=n` – return stored watts per kilogram history.
 - `POST /webhook` – Strava webhook endpoint used to fetch new data immediately.
 
 A Postman collection `abcy-data.postman_collection.json` is included to help
@@ -108,9 +113,11 @@ DATA_DIR/
         meta.json.zst
         streams.json.zst
     ftp.json
+    weight.json
+    wkg.json
 ```
 
-Metadata and streams are encoded with `serde_json` and compressed using zstd. The `ftp.json` file stores your Functional Threshold Power history used to compute IF and TSS.
+Metadata and streams are encoded with `serde_json` and compressed using zstd. The `ftp.json` file stores your Functional Threshold Power history used to compute IF and TSS. The `weight.json` file tracks weight changes and `wkg.json` stores watts per kilogram over time.
 
 ## Adding Another User
 

--- a/tests/ftp.rs
+++ b/tests/ftp.rs
@@ -28,3 +28,12 @@ async fn ftp_history_update() {
     assert_eq!(recent.len(), 1);
     assert_eq!(recent[0].ftp, 250.0);
 }
+
+#[tokio::test]
+async fn ftp_updates_wkg() {
+    let storage = make_storage();
+    storage.set_ftp(255.0).await.unwrap();
+    let weight = storage.current_weight().await.unwrap();
+    let wkg = storage.current_wkg().await.unwrap();
+    assert!((wkg - 255.0 / weight).abs() < 1e-6);
+}

--- a/tests/weight.rs
+++ b/tests/weight.rs
@@ -1,0 +1,31 @@
+use abcy_data::{storage::Storage, utils::Storage as StorageCfg};
+use tempfile::tempdir;
+
+fn make_storage() -> Storage {
+    let dir = tempdir().unwrap();
+    let cfg = StorageCfg { data_dir: dir.path().to_str().unwrap().into(), download_count: 1, user: "t".into() };
+    Storage::new(&cfg)
+}
+
+#[tokio::test]
+async fn weight_and_wkg_update() {
+    let storage = make_storage();
+    // default weight entry
+    let hist1 = storage.get_weight_history().await.unwrap();
+    assert_eq!(hist1.len(), 1);
+    assert_eq!(hist1[0].weight, 75.0);
+
+    storage.set_weight(83.5).await.unwrap();
+    let current = storage.current_weight().await.unwrap();
+    assert_eq!(current, 83.5);
+
+    let hist2 = storage.get_weight_history().await.unwrap();
+    assert_eq!(hist2.len(), 2);
+    assert_eq!(hist2.last().unwrap().weight, 83.5);
+
+    let wkg = storage.current_wkg().await.unwrap();
+    assert!((wkg - 240.0 / 83.5).abs() < 1e-6);
+
+    let wkg_hist = storage.wkg_history(Some(1)).await.unwrap();
+    assert_eq!(wkg_hist.len(), 1);
+}


### PR DESCRIPTION
## Summary
- list weight and watts-per-kilogram endpoints in `AGENTS.md`
- mention `ftp.json`, `weight.json` and `wkg.json` in the agent guide
- add `ftp_updates_wkg` test to ensure W/kg updates on FTP changes

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686259a21f80832084bd470e2fe97b56