### PR TITLE
Add activity type filtering to stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,13 @@ The server listens on `localhost:8080` by default.
 - `GET /wkg` – return watts per kilogram using the current FTP and weight
 - `GET /wkg/history?count=n` – return stored watts per kilogram history
 - `POST /webhook` – Strava webhook used to trigger immediate downloads
+- `GET /stats?period=week&ids=1,2&types=Ride` – aggregated statistics grouped by day, week,
+  month or year. Optional comma-separated `ids` and `types` filters restrict the
+  activities considered. The `period` parameter accepts `day`, `week`, `month`
+  or `year`.
+  The response includes ride count, total distance, average weighted power,
+  average intensity factor, total training stress and average speed for each
+  period returned.
 
 Activity summaries now include normalized power (NP), intensity factor (IF) and training stress score (TSS) calculated using the stored FTP value.
 

--- a/README.md
+++ b/README.md
@@ -97,10 +97,28 @@ On startup the app will:
 - `POST /weight` – append a new weight value.
 - `GET /wkg` – return the current watts per kilogram using FTP and weight.
 - `GET /wkg/history?count=n` – return stored watts per kilogram history.
+- `GET /stats?period=week&ids=1,2&types=Ride` – aggregated statistics grouped by day, week,
+  month or year. Optional filters allow specifying a comma-separated list of activity
+  IDs with `ids` and a list of activity types with `types` (e.g. `Ride`, `Run`).
+  Available IDs can be obtained from the `/activities` endpoint.
 - `POST /webhook` – Strava webhook endpoint used to fetch new data immediately.
 
 A Postman collection `abcy-data.postman_collection.json` is included to help
 test the endpoints. Set the `base_url` variable to your server's address.
+
+Example statistics request:
+
+```bash
+curl "http://localhost:8080/stats?period=month&ids=123,124&types=Ride"
+```
+
+This returns aggregated metrics for the selected Ride activities grouped by month.
+The `period` parameter accepts `day`, `week`, `month` or `year` to control
+how statistics are grouped. Each response entry contains the period label,
+ride count, total distance, average weighted power, average intensity
+factor, cumulative training stress and average speed. Provide a comma
+separated list of activity IDs through `ids` to limit the aggregation and
+use the `types` parameter to restrict results to certain activity types.
 Automated tools can refer to `AGENTS.md` for a short Python example.
 
 Downloaded activities are organised as:

--- a/abcy-data.postman_collection.json
+++ b/abcy-data.postman_collection.json
@@ -26,6 +26,14 @@
       "request": { "method": "GET", "url": "{{base_url}}/raw/{{path}}" }
     },
     {
+      "name": "Activity Stats",
+      "request": {
+        "method": "GET",
+        "url": "{{base_url}}/stats?period={{period}}&ids={{ids}}&types={{types}}"
+      },
+      "description": "Return aggregated metrics grouped by `period`. Valid values are `day`, `week`, `month` and `year`. Optional `ids` and `types` query strings filter the activities."
+    },
+    {
       "name": "Send Webhook Event",
       "request": {
         "method": "POST",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod fetch;
 pub mod storage;
 pub mod web;
 pub mod schema;
+pub mod stats;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -36,6 +36,8 @@ pub struct ActivitySummary {
     pub intensity_factor: Option<f64>,
     /// Training stress score if available
     pub training_stress_score: Option<f64>,
+    /// Activity type such as Ride or Run if available
+    pub activity_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,114 @@
+use chrono::{Datelike, NaiveDate};
+use serde::Serialize;
+use std::collections::{BTreeMap, HashSet};
+
+use crate::storage::Storage;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Period {
+    Day,
+    Week,
+    Month,
+    Year,
+}
+
+#[derive(Debug, Default)]
+struct Acc {
+    count: usize,
+    distance: f64,
+    wp_sum: f64,
+    wp_count: usize,
+    if_sum: f64,
+    if_count: usize,
+    tss_sum: f64,
+    spd_sum: f64,
+    spd_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StatsEntry {
+    pub period: String,
+    pub rides: usize,
+    pub distance: f64,
+    pub weighted_power: Option<f64>,
+    pub intensity_factor: Option<f64>,
+    pub training_stress: Option<f64>,
+    pub average_speed: Option<f64>,
+}
+
+fn period_key(date: NaiveDate, p: Period) -> String {
+    match p {
+        Period::Day => date.to_string(),
+        Period::Week => {
+            let iso = date.iso_week();
+            format!("{}-W{:02}", iso.year(), iso.week())
+        }
+        Period::Month => format!("{}-{:02}", date.year(), date.month()),
+        Period::Year => format!("{}", date.year()),
+    }
+}
+
+impl Storage {
+    pub async fn activity_stats(
+        &self,
+        period: Period,
+        ids: Option<&[u64]>,
+        types: Option<&[String]>,
+    ) -> anyhow::Result<Vec<StatsEntry>> {
+        let acts = self.list_activities(None).await?;
+        let filter: Option<HashSet<u64>> = ids.map(|l| l.iter().copied().collect());
+        let type_filter: Option<HashSet<String>> = types.map(|l| l.iter().cloned().collect());
+        let mut map: BTreeMap<String, Acc> = BTreeMap::new();
+        for a in acts {
+            if let Some(ref f) = filter {
+                if !f.contains(&a.id) {
+                    continue;
+                }
+            }
+            let summary = self.load_activity_summary(a.id).await?;
+            if let Some(ref tf) = type_filter {
+                if let Some(ref t) = summary.activity_type {
+                    if !tf.contains(t) {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+            }
+            let dt = chrono::DateTime::parse_from_rfc3339(&summary.start_date)?.naive_utc();
+            let key = period_key(dt.date(), period);
+            let entry = map.entry(key).or_default();
+            entry.count += 1;
+            entry.distance += summary.distance;
+            if let Some(wp) = summary.average_power {
+                entry.wp_sum += wp;
+                entry.wp_count += 1;
+            }
+            if let Some(ifv) = summary.intensity_factor {
+                entry.if_sum += ifv;
+                entry.if_count += 1;
+            }
+            if let Some(tss) = summary.training_stress_score {
+                entry.tss_sum += tss;
+            }
+            if let Some(spd) = summary.average_speed {
+                entry.spd_sum += spd;
+                entry.spd_count += 1;
+            }
+        }
+        let mut out = Vec::new();
+        for (period, acc) in map {
+            out.push(StatsEntry {
+                period,
+                rides: acc.count,
+                distance: acc.distance,
+                weighted_power: if acc.wp_count > 0 { Some(acc.wp_sum / acc.wp_count as f64) } else { None },
+                intensity_factor: if acc.if_count > 0 { Some(acc.if_sum / acc.if_count as f64) } else { None },
+                training_stress: if acc.count > 0 { Some(acc.tss_sum) } else { None },
+                average_speed: if acc.spd_count > 0 { Some(acc.spd_sum / acc.spd_count as f64) } else { None },
+            });
+        }
+        Ok(out)
+    }
+}
+

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -365,6 +365,11 @@ impl Storage {
             .and_then(|m| m.get("summary_polyline"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        let activity_type = detail
+            .meta
+            .get("type")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
         Ok(crate::schema::ActivitySummary {
             id: detail.meta.get("id").and_then(|v| v.as_u64()).unwrap_or(id),
             name: detail
@@ -389,6 +394,7 @@ impl Storage {
             normalized_power,
             intensity_factor,
             training_stress_score,
+            activity_type,
         })
     }
 

--- a/tests/activity_stats.rs
+++ b/tests/activity_stats.rs
@@ -1,0 +1,37 @@
+use abcy_data::{storage::Storage, utils::Storage as StorageCfg, stats::Period};
+use serde_json::json;
+use tempfile::tempdir;
+
+fn make_storage() -> Storage {
+    let dir = tempdir().unwrap();
+    let cfg = StorageCfg { data_dir: dir.path().to_str().unwrap().into(), download_count: 1, user: "t".into() };
+    Storage::new(&cfg)
+}
+
+#[tokio::test]
+async fn stats_aggregation() {
+    let storage = make_storage();
+    let meta1 = json!({"id":1,"name":"r1","start_date":"2024-01-01T00:00:00Z","distance":10.0,"type":"Ride"});
+    let streams1 = json!({"time": [0,10], "watts": [100,200]});
+    storage.save(&meta1, &streams1).await.unwrap();
+
+    let meta2 = json!({"id":2,"name":"r2","start_date":"2024-01-02T00:00:00Z","distance":5.0,"type":"Run"});
+    let streams2 = json!({"time": [0,10], "watts": [150,250]});
+    storage.save(&meta2, &streams2).await.unwrap();
+
+    let stats = storage.activity_stats(Period::Day, None, None).await.unwrap();
+    assert_eq!(stats.len(), 2);
+    assert!(stats.iter().any(|s| s.distance > 9.0));
+
+    let filtered = storage.activity_stats(Period::Day, Some(&[1]), None).await.unwrap();
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].rides, 1);
+
+    let type_filtered = storage
+        .activity_stats(Period::Day, None, Some(&["Ride".to_string()]))
+        .await
+        .unwrap();
+    assert_eq!(type_filtered.len(), 1);
+    assert_eq!(type_filtered[0].rides, 1);
+}
+


### PR DESCRIPTION
## Summary
- document stats endpoint filter parameters
- allow filtering statistics by activity type
- include activity type field in summaries
- update Postman collection
- add tests for stats filtering by type

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68626795e6888320920357f99d3f589c