### PR TITLE
Scale down EnduroScore

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ On startup the app will:
 
 The service tracks two additional metrics derived from your recent training:
 
-- **EnduroScore** – gauges long-ride durability using the average distance and
-  duration of your long rides, weekly volume and the last four weeks of training
+- **EnduroScore** – gauges long-ride durability using the typical distance and
+  duration of your long rides (measured as kilometres × hours divided by twenty),
+  weekly volume and the last four weeks of training
   stress. The score decays if no long ride was completed in the past 14 days.
 - **FitnessScore** – reflects overall aerobic conditioning. It combines weekly
   training hours (times four), the four‑week average Training Stress Score

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -297,7 +297,8 @@ impl Storage {
                 }
                 if let Some(tss) = summary.training_stress_score { tss_sum += tss; }
                 if summary.distance >= 80000.0 {
-                    long_products.push(summary.distance * summary.duration as f64);
+                    let km_hours = (summary.distance / 1000.0) * (summary.duration as f64 / 3600.0);
+                    long_products.push(km_hours);
                     if last_long.map_or(true, |d| days < d) { last_long = Some(days); }
                 }
             }
@@ -305,7 +306,7 @@ impl Storage {
         let avg_long = if !long_products.is_empty() {
             long_products.iter().sum::<f64>() / long_products.len() as f64
         } else { 0.0 };
-        let mut score = avg_long / 10000.0 + week_volume + tss_sum / 100.0;
+        let mut score = avg_long / 20.0 + week_volume + tss_sum / 100.0;
         if let Some(days) = last_long {
             if days > 14 { score *= 0.9_f64.powf((days - 14) as f64); }
         }

--- a/tests/scores.rs
+++ b/tests/scores.rs
@@ -31,8 +31,9 @@ async fn enduro_score_computation() {
     add_activity(&storage, 3, 3, 50000.0, 7200, 100.0).await;
 
     let score = storage.update_enduro().await.unwrap();
-    let avg_long = (100000.0 * 14400.0 + 100000.0 * 10800.0) / 2.0;
-    let expected = avg_long / 10000.0 + 6.0 + 4.8;
+    let avg_long = (100000.0 / 1000.0 * (14400.0 / 3600.0)
+        + 100000.0 / 1000.0 * (10800.0 / 3600.0)) / 2.0;
+    let expected = avg_long / 20.0 + 6.0 + 4.8;
     assert!((score - expected).abs() < 1e-6);
     let hist = storage.enduro_history(None).await.unwrap();
     assert_eq!(hist.len(), 1);
@@ -46,7 +47,7 @@ async fn enduro_score_decay() {
     add_activity(&storage, 2, 1, 50000.0, 7200, 100.0).await;
 
     let score = storage.update_enduro().await.unwrap();
-    let base = 144000.0 + 2.0 + 3.0;
+    let base = (100000.0 / 1000.0 * (14400.0 / 3600.0)) / 20.0 + 2.0 + 3.0;
     let expected = base * 0.9_f64.powf(6.0);
     assert!((score - expected).abs() < 1e-6);
 }


### PR DESCRIPTION
## Summary
- shrink EnduroScore by dividing long ride km×hour products by 20
- document the change in README
- adjust tests for the new formula

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6865a240a6188320b0e9b04732f929e6