### PR TITLE
Expose weighted average power and more in summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Scores roughly range as follows:
 
 - `GET /activities?count=n` – list activities ordered by newest first. If `count` is omitted all headers are returned.
 - `GET /activity/{id}` – full metadata and streams (time and power) for an activity.
-- `GET /activity/{id}/summary` – small summary with duration, power and training metrics.
+- `GET /activity/{id}/summary` – small summary including duration, weighted average power, average speed, intensity factor, training stress score and average heart rate.
 - `GET /files` – recursive listing of everything under `DATA_DIR`.
 - `GET /raw/{path}` – return a stored file by relative path.
 - `GET /ftp` – return the current FTP value.

--- a/openapi.json
+++ b/openapi.json
@@ -50,7 +50,32 @@
           }
         ],
         "responses": {
-          "200": {"description": "Summary data"},
+          "200": {
+            "description": "Summary data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {"type": "integer"},
+                    "name": {"type": "string"},
+                    "start_date": {"type": "string"},
+                    "distance": {"type": "number"},
+                    "duration": {"type": "integer"},
+                    "weighted_average_power": {"type": "number"},
+                    "average_speed": {"type": "number"},
+                    "pr_count": {"type": "integer"},
+                    "average_heartrate": {"type": "number"},
+                    "summary_polyline": {"type": "string"},
+                    "normalized_power": {"type": "number"},
+                    "intensity_factor": {"type": "number"},
+                    "training_stress_score": {"type": "number"},
+                    "activity_type": {"type": "string"}
+                  }
+                }
+              }
+            }
+          },
           "404": {"description": "Not found"}
         }
       }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -21,7 +21,8 @@ pub struct ActivitySummary {
     pub start_date: String,
     pub distance: f64,
     pub duration: i64,
-    pub average_power: Option<f64>,
+    /// Weighted average power in watts if available
+    pub weighted_average_power: Option<f64>,
     /// Average speed in meters per second if available
     pub average_speed: Option<f64>,
     /// Number of personal records from segments if available

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -80,7 +80,7 @@ impl Storage {
             let entry = map.entry(key).or_default();
             entry.count += 1;
             entry.distance += summary.distance;
-            if let Some(wp) = summary.average_power {
+            if let Some(wp) = summary.weighted_average_power {
                 entry.wp_sum += wp;
                 entry.wp_count += 1;
             }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -435,7 +435,7 @@ impl Storage {
             .and_then(|v| v.as_i64())
             .or_else(|| detail.streams.time.last().cloned())
             .unwrap_or(0);
-        let average_power = detail
+        let weighted_average_power = detail
             .meta
             .get("weighted_average_watts")
             .and_then(|v| v.as_f64())
@@ -516,7 +516,7 @@ impl Storage {
                 .to_string(),
             distance: detail.meta.get("distance").and_then(|v| v.as_f64()).unwrap_or(0.0),
             duration,
-            average_power,
+            weighted_average_power,
             average_speed,
             pr_count,
             average_heartrate,

--- a/tests/activity_summary.rs
+++ b/tests/activity_summary.rs
@@ -31,7 +31,7 @@ async fn summary_computation() {
     let summary = storage.load_activity_summary(1).await.unwrap();
     assert_eq!(summary.id, 1);
     assert_eq!(summary.duration, 30);
-    assert!(summary.average_power.unwrap() > 0.0);
+    assert!(summary.weighted_average_power.unwrap() > 0.0);
     assert!(summary.average_speed.unwrap() > 0.0);
     assert_eq!(summary.pr_count, Some(2));
     assert!(summary.average_heartrate.unwrap() > 0.0);

--- a/tests/dragonride_summary.rs
+++ b/tests/dragonride_summary.rs
@@ -10,14 +10,14 @@ fn make_storage() -> Storage {
 }
 
 #[tokio::test]
-async fn dragonride_average_power() {
+async fn dragonride_weighted_average_power() {
     let storage = make_storage();
     let data: Value = serde_json::from_str(&fs::read_to_string("dragonride.json").unwrap()).unwrap();
     let meta = &data["meta"];
     let streams = &data["streams"];
     storage.save(meta, streams).await.unwrap();
     let summary = storage.load_activity_summary(meta["id"].as_u64().unwrap()).await.unwrap();
-    assert_eq!(summary.average_power.unwrap().round() as i64, 160);
+    assert_eq!(summary.weighted_average_power.unwrap().round() as i64, 160);
     let np = summary.normalized_power.unwrap();
     let ifv = summary.intensity_factor.unwrap();
     let tss = summary.training_stress_score.unwrap();


### PR DESCRIPTION
## Summary
- rename `average_power` to `weighted_average_power`
- include new field name in summary serialization and stats
- document full summary response in `openapi.json`
- clarify README about metrics returned by `/activity/{id}/summary`
- update unit tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686a892ec9cc83209b2e62f17d89d89e