### PR TITLE
Add trend information to activity summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Scores roughly range as follows:
 
 - `GET /activities?count=n` – list activities ordered by newest first. If `count` is omitted all headers are returned.
 - `GET /activity/{id}` – full metadata and streams (time and power) for an activity.
-- `GET /activity/{id}/summary` – small summary including duration, weighted average power, average speed, intensity factor, training stress score and average heart rate.
+- `GET /activity/{id}/summary` – small summary including duration, weighted average power, average speed, intensity factor, training stress score and average heart rate. The response includes a `trend` section comparing recent rides.
 - `GET /files` – recursive listing of everything under `DATA_DIR`.
 - `GET /raw/{path}` – return a stored file by relative path.
 - `GET /ftp` – return the current FTP value.
@@ -120,6 +120,7 @@ Scores roughly range as follows:
 - `GET /enduro/history?count=n` – return EnduroScore history ordered by newest first.
 - `GET /fitness` – compute the current FitnessScore and store it.
 - `GET /fitness/history?count=n` – return FitnessScore history ordered by newest first.
+- `GET /trend` – return performance trends comparing the last ten rides to the previous ten. This is the same data available in the `trend` field of activity summaries.
 - `GET /openapi.json` – machine-readable OpenAPI description of all endpoints.
 - `GET /stats?period=week&ids=1,2&types=Ride` – aggregated statistics grouped by day, week,
   month or year. Optional filters allow specifying a comma-separated list of activity

--- a/openapi.json
+++ b/openapi.json
@@ -64,13 +64,24 @@
                     "duration": {"type": "integer"},
                     "weighted_average_power": {"type": "number"},
                     "average_speed": {"type": "number"},
+                    "max_speed": {"type": "number"},
                     "pr_count": {"type": "integer"},
                     "average_heartrate": {"type": "number"},
                     "summary_polyline": {"type": "string"},
                     "normalized_power": {"type": "number"},
                     "intensity_factor": {"type": "number"},
                     "training_stress_score": {"type": "number"},
-                    "activity_type": {"type": "string"}
+                    "activity_type": {"type": "string"},
+                    "trend": {
+                      "type": "object",
+                      "properties": {
+                        "avg_speed": {"type": "string"},
+                        "max_speed": {"type": "string"},
+                        "tss": {"type": "string"},
+                        "intensity": {"type": "string"},
+                        "power": {"type": "string"}
+                      }
+                    }
                   }
                 }
               }
@@ -116,6 +127,7 @@
     "/enduro/history": {"get": {"summary": "EnduroScore history", "responses": {"200": {"description": "History"}}}},
     "/fitness": {"get": {"summary": "Current FitnessScore", "responses": {"200": {"description": "Fitness"}}}},
     "/fitness/history": {"get": {"summary": "FitnessScore history", "responses": {"200": {"description": "History"}}}},
+    "/trend": {"get": {"summary": "Recent trends", "responses": {"200": {"description": "Trends"}}}},
     "/stats": {
       "get": {
         "summary": "Aggregated statistics",

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -25,6 +25,8 @@ pub struct ActivitySummary {
     pub weighted_average_power: Option<f64>,
     /// Average speed in meters per second if available
     pub average_speed: Option<f64>,
+    /// Maximum speed in meters per second if available
+    pub max_speed: Option<f64>,
     /// Number of personal records from segments if available
     pub pr_count: Option<i64>,
     /// Average heart rate in bpm if available
@@ -39,6 +41,17 @@ pub struct ActivitySummary {
     pub training_stress_score: Option<f64>,
     /// Activity type such as Ride or Run if available
     pub activity_type: Option<String>,
+    /// Performance trend classification comparing recent rides
+    pub trend: Option<TrendSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TrendSummary {
+    pub avg_speed: String,
+    pub max_speed: String,
+    pub tss: String,
+    pub intensity: String,
+    pub power: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/tests/trend.rs
+++ b/tests/trend.rs
@@ -1,0 +1,45 @@
+use abcy_data::{storage::Storage, utils::Storage as StorageCfg};
+use serde_json::json;
+use tempfile::tempdir;
+
+fn make_storage() -> Storage {
+    let dir = tempdir().unwrap();
+    let cfg = StorageCfg { data_dir: dir.path().to_str().unwrap().into(), download_count: 1, user: "t".into() };
+    Storage::new(&cfg)
+}
+
+async fn add_activity(storage: &Storage, id: u64, day: u64, avg_speed: f64, max_speed: f64, tss: f64, intensity: f64, power: f64) {
+    let date = format!("2024-01-{:02}T00:00:00Z", day);
+    let meta = json!({
+        "id": id,
+        "name": "ride",
+        "start_date": date,
+        "distance": 10000.0,
+        "elapsed_time": 1000,
+        "average_speed": avg_speed,
+        "max_speed": max_speed,
+        "training_stress_score": tss,
+        "intensity_factor": intensity,
+        "weighted_average_watts": power
+    });
+    let streams = json!({"time": [0,1000]});
+    storage.save(&meta, &streams).await.unwrap();
+}
+
+#[tokio::test]
+async fn trend_computation() {
+    let storage = make_storage();
+    for i in 0..10 {
+        add_activity(&storage, i as u64, i as u64 + 1, 10.0, 20.0, 100.0, 0.95, 200.0).await;
+    }
+    for i in 10..20 {
+        add_activity(&storage, i as u64, i as u64 + 1, 11.0, 20.0, 105.0, 1.0, 230.0).await;
+    }
+
+    let trend = storage.recent_trends().await.unwrap();
+    assert_eq!(trend.avg_speed, "very_high");
+    assert_eq!(trend.max_speed, "normal");
+    assert_eq!(trend.tss, "high");
+    assert_eq!(trend.intensity, "high");
+    assert_eq!(trend.power, "very_high");
+}


### PR DESCRIPTION
## Summary
- extend `ActivitySummary` with an optional `trend` field
- compute trend data in the summary API handler
- document new field in README and OpenAPI spec

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686ac1f48abc8320b0bb5ee4be31a88b