### PR TITLE
Adjust trend comparison to use 3 month periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Scores roughly range as follows:
 - `GET /enduro/history?count=n` – return EnduroScore history ordered by newest first.
 - `GET /fitness` – compute the current FitnessScore and store it.
 - `GET /fitness/history?count=n` – return FitnessScore history ordered by newest first.
-- `GET /trend` – return performance trends comparing the last ten rides to the previous ten. This is the same data available in the `trend` field of activity summaries.
+- `GET /trend` – return performance trends comparing the last three months of rides to the prior three months. This is the same data available in the `trend` field of activity summaries.
 - `GET /openapi.json` – machine-readable OpenAPI description of all endpoints.
 - `GET /stats?period=week&ids=1,2&types=Ride` – aggregated statistics grouped by day, week,
   month or year. Optional filters allow specifying a comma-separated list of activity

--- a/tests/trend.rs
+++ b/tests/trend.rs
@@ -8,8 +8,9 @@ fn make_storage() -> Storage {
     Storage::new(&cfg)
 }
 
-async fn add_activity(storage: &Storage, id: u64, day: u64, avg_speed: f64, max_speed: f64, tss: f64, intensity: f64, power: f64) {
-    let date = format!("2024-01-{:02}T00:00:00Z", day);
+async fn add_activity(storage: &Storage, id: u64, days_ago: i64, avg_speed: f64, max_speed: f64, tss: f64, intensity: f64, power: f64) {
+    let dt = chrono::Utc::now().naive_utc().date() - chrono::Duration::days(days_ago);
+    let date = dt.and_hms_opt(0, 0, 0).unwrap().format("%Y-%m-%dT%H:%M:%SZ").to_string();
     let meta = json!({
         "id": id,
         "name": "ride",
@@ -30,16 +31,16 @@ async fn add_activity(storage: &Storage, id: u64, day: u64, avg_speed: f64, max_
 async fn trend_computation() {
     let storage = make_storage();
     for i in 0..10 {
-        add_activity(&storage, i as u64, i as u64 + 1, 10.0, 20.0, 100.0, 0.95, 200.0).await;
+        add_activity(&storage, 20 + i as u64, 10 - i as i64, 11.0, 20.0, 105.0, 1.0, 230.0).await;
     }
-    for i in 10..20 {
-        add_activity(&storage, i as u64, i as u64 + 1, 11.0, 20.0, 105.0, 1.0, 230.0).await;
+    for i in 0..10 {
+        add_activity(&storage, i as u64, 100 + i as i64, 10.0, 20.0, 100.0, 0.95, 200.0).await;
     }
 
     let trend = storage.recent_trends().await.unwrap();
-    assert_eq!(trend.avg_speed, "very_high");
-    assert_eq!(trend.max_speed, "normal");
+    assert_eq!(trend.avg_speed, "high");
+    assert_eq!(trend.max_speed, "same");
     assert_eq!(trend.tss, "high");
     assert_eq!(trend.intensity, "high");
-    assert_eq!(trend.power, "very_high");
+    assert_eq!(trend.power, "high");
 }


### PR DESCRIPTION
## Summary
- compute recent trends using the last three months of rides compared to the previous three
- adjust performance classification thresholds to ±5% and ±20%
- update trend test for new logic
- document updated behaviour in the README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686acad008348320903fd2b3f656c393