### PR TITLE
Add elevation gain to activity summaries

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -61,6 +61,7 @@
                     "name": {"type": "string"},
                     "start_date": {"type": "string"},
                     "distance": {"type": "number"},
+                    "total_elevation_gain": {"type": "number"},
                     "duration": {"type": "integer"},
                     "weighted_average_power": {"type": "number"},
                     "average_speed": {"type": "number"},

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -20,6 +20,8 @@ pub struct ActivitySummary {
     pub name: String,
     pub start_date: String,
     pub distance: f64,
+    /// Total elevation gain in meters if available
+    pub total_elevation_gain: Option<f64>,
     pub duration: i64,
     /// Weighted average power in watts if available
     pub weighted_average_power: Option<f64>,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -446,6 +446,10 @@ impl Storage {
                 None
             });
         let distance = detail.meta.get("distance").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let total_elevation_gain = detail
+            .meta
+            .get("total_elevation_gain")
+            .and_then(|v| v.as_f64());
         let average_speed = detail
             .meta
             .get("average_speed")
@@ -520,6 +524,7 @@ impl Storage {
                 .unwrap_or("")
                 .to_string(),
             distance: detail.meta.get("distance").and_then(|v| v.as_f64()).unwrap_or(0.0),
+            total_elevation_gain,
             duration,
             weighted_average_power,
             average_speed,

--- a/tests/activity_summary.rs
+++ b/tests/activity_summary.rs
@@ -16,6 +16,7 @@ async fn summary_computation() {
         "name":"ride",
         "start_date":"2024-01-01",
         "distance":1.0,
+        "total_elevation_gain":10.0,
         "elapsed_time":30,
         "average_speed":0.033,
         "pr_count":2,
@@ -36,4 +37,5 @@ async fn summary_computation() {
     assert_eq!(summary.pr_count, Some(2));
     assert!(summary.average_heartrate.unwrap() > 0.0);
     assert_eq!(summary.summary_polyline, Some("xyz".into()));
+    assert_eq!(summary.total_elevation_gain, Some(10.0));
 }

--- a/tests/dragonride_summary.rs
+++ b/tests/dragonride_summary.rs
@@ -24,4 +24,5 @@ async fn dragonride_weighted_average_power() {
     assert!((np - 170.09).abs() < 0.1);
     assert!((ifv - 0.7087).abs() < 0.001);
     assert!((tss - 443.18).abs() < 1.0);
+    assert_eq!(summary.total_elevation_gain, Some(2183.0));
 }


### PR DESCRIPTION
## Summary
- track `total_elevation_gain` in `ActivitySummary`
- parse elevation gain from activity metadata
- expose new field via `/activity/{id}/summary` endpoint
- document the response property in openapi
- test elevation gain handling

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ace3a497883209b65229e09fe7b4a