### PR TITLE
Add Ray 2.7 arm-ready cluster image with ConnectorX

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ name: Docker Build
 on:
   push:
     branches: ["main"]
+  pull_request:
+    branches: ["**"]
 
 jobs:
   build:
@@ -31,17 +33,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Ray cluster image
+      - name: Build and (conditionally) push Ray cluster image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/ray-cluster/Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/ray-cluster:2.7.0
             ghcr.io/${{ github.repository_owner }}/ray-cluster:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,3 +16,33 @@ jobs:
         with:
           context: .
           push: false
+
+  ray-cluster:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,amd64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Ray cluster image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/ray-cluster/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/ray-cluster:2.7.0
+            ghcr.io/${{ github.repository_owner }}/ray-cluster:latest
+          platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -124,18 +124,19 @@ The container expects the environment variables described above at runtime.
 
 A dedicated Ray worker image is available for Graviton/arm64 environments. The
 Dockerfile at `docker/ray-cluster/Dockerfile` starts from
-`rayproject/ray:2.7.0-py310`, installs ConnectorX plus MSSQL database drivers,
-and verifies ConnectorX by running a SQLite round trip during the build. Build
-it locally for arm64 with:
+`rayproject/ray:2.7.0-py312`, asserts Python 3.12 is active, installs
+ConnectorX plus MSSQL database drivers, and verifies ConnectorX by running a
+SQLite round trip during the build. Build it locally for arm64 with:
 
 ```bash
 docker build -f docker/ray-cluster/Dockerfile -t ghcr.io/<owner>/ray-cluster:local --platform linux/arm64 .
 ```
 
-GitHub Actions publishes multi-architecture images to GHCR with the tags
-`ray-cluster:2.7.0` and `ray-cluster:latest`.
+GitHub Actions builds the image for pull requests and publishes
+multi-architecture images to GHCR with the tags `ray-cluster:2.7.0` and
+`ray-cluster:latest` on pushes to `main`.
 
 ### Continuous Integration
 
-GitHub Actions run `cargo test` for each pull request and build the Docker image on every push to `main`.
+GitHub Actions run `cargo test` for each pull request, build the Ray cluster image on pull requests, and publish Docker images on every push to `main`.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ docker build -t abcy-data .
 
 The container expects the environment variables described above at runtime.
 
+### Ray 2.7 cluster image
+
+A dedicated Ray worker image is available for Graviton/arm64 environments. The
+Dockerfile at `docker/ray-cluster/Dockerfile` starts from
+`rayproject/ray:2.7.0-py310`, installs ConnectorX plus MSSQL database drivers,
+and verifies ConnectorX by running a SQLite round trip during the build. Build
+it locally for arm64 with:
+
+```bash
+docker build -f docker/ray-cluster/Dockerfile -t ghcr.io/<owner>/ray-cluster:local --platform linux/arm64 .
+```
+
+GitHub Actions publishes multi-architecture images to GHCR with the tags
+`ray-cluster:2.7.0` and `ray-cluster:latest`.
+
 ### Continuous Integration
 
 GitHub Actions run `cargo test` for each pull request and build the Docker image on every push to `main`.

--- a/docker/ray-cluster/Dockerfile
+++ b/docker/ray-cluster/Dockerfile
@@ -1,0 +1,43 @@
+FROM rayproject/ray:2.7.0-py310
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        python3-dev \
+        unixodbc-dev \
+        freetds-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+    connectorx>=0.3.2 \
+    pymssql>=2.2.10 \
+    sqlalchemy>=2.0
+
+RUN python - <<'PY'
+import connectorx as cx
+import sqlite3
+import tempfile
+import os
+import pymssql
+
+print(f"connectorx version: {cx.__version__}")
+
+tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+path = tmp.name
+tmp.close()
+
+conn = sqlite3.connect(path)
+conn.execute("create table t(x int)")
+conn.execute("insert into t values (1)")
+conn.commit()
+conn.close()
+
+frame = cx.read_sql(f"sqlite:///{path}", "select x from t")
+assert frame.iloc[0, 0] == 1
+print("connectorx read_sql against sqlite succeeded", frame.to_dict())
+
+os.remove(path)
+print("pymssql import succeeded", pymssql.__version__)
+PY

--- a/docker/ray-cluster/Dockerfile
+++ b/docker/ray-cluster/Dockerfile
@@ -1,14 +1,21 @@
-FROM rayproject/ray:2.7.0-py310
+FROM rayproject/ray:2.7.0-py312
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
-        python3-dev \
+        python3.12-dev \
         unixodbc-dev \
         freetds-dev \
     && rm -rf /var/lib/apt/lists/*
+
+RUN python - <<'PY'
+import sys
+
+assert sys.version_info[:2] == (3, 12), f"Expected Python 3.12, got {sys.version}"
+print(f"Python version OK: {sys.version}")
+PY
 
 RUN pip install --no-cache-dir \
     connectorx>=0.3.2 \


### PR DESCRIPTION
## Summary
- add a Ray 2.7 base Dockerfile tailored for arm/Graviton with ConnectorX and MSSQL drivers, including build-time verification
- document how to build and consume the Ray cluster image alongside existing Docker guidance
- extend CI to build and publish multi-arch Ray cluster images to GHCR

## Testing
- cargo test --locked --all-targets -- --test-threads=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693782dadb808320bb1ce19ee5408ca9)