### PR TITLE
Fix GHCR tag casing for ray cluster image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,3 +16,36 @@ jobs:
         with:
           context: .
           push: false
+
+  ray-cluster:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,amd64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Derive lowercase owner
+        id: owner
+        run: echo "name=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Ray cluster image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/ray-cluster/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ steps.owner.outputs.name }}/ray-cluster:2.7.0
+            ghcr.io/${{ steps.owner.outputs.name }}/ray-cluster:latest
+          platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ docker build -t abcy-data .
 
 The container expects the environment variables described above at runtime.
 
+### Ray 2.7 cluster image
+
+A dedicated Ray worker image is available for Graviton/arm64 environments. The
+Dockerfile at `docker/ray-cluster/Dockerfile` starts from
+`rayproject/ray:2.7.0-py310`, installs ConnectorX plus MSSQL database drivers,
+and verifies ConnectorX by running a SQLite round trip during the build. Build
+it locally for arm64 with:
+
+```bash
+docker build -f docker/ray-cluster/Dockerfile -t ghcr.io/<owner>/ray-cluster:local --platform linux/arm64 .
+```
+
+GitHub Actions publishes multi-architecture images to GHCR with the tags
+`ray-cluster:2.7.0` and `ray-cluster:latest`.
+
 ### Continuous Integration
 
 GitHub Actions run `cargo test` for each pull request and build the Docker image on every push to `main`.

--- a/docker/ray-cluster/Dockerfile
+++ b/docker/ray-cluster/Dockerfile
@@ -1,0 +1,43 @@
+FROM rayproject/ray:2.7.0-py310
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        python3-dev \
+        unixodbc-dev \
+        freetds-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+    connectorx>=0.3.2 \
+    pymssql>=2.2.10 \
+    sqlalchemy>=2.0
+
+RUN python - <<'PY'
+import connectorx as cx
+import sqlite3
+import tempfile
+import os
+import pymssql
+
+print(f"connectorx version: {cx.__version__}")
+
+tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+path = tmp.name
+tmp.close()
+
+conn = sqlite3.connect(path)
+conn.execute("create table t(x int)")
+conn.execute("insert into t values (1)")
+conn.commit()
+conn.close()
+
+frame = cx.read_sql(f"sqlite:///{path}", "select x from t")
+assert frame.iloc[0, 0] == 1
+print("connectorx read_sql against sqlite succeeded", frame.to_dict())
+
+os.remove(path)
+print("pymssql import succeeded", pymssql.__version__)
+PY


### PR DESCRIPTION
## Summary
- derive a lowercase GHCR owner value when building the ray cluster image
- use the lowercase owner in pushed tags to avoid invalid repository names

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693782dadb808320bb1ce19ee5408ca9)